### PR TITLE
fix build

### DIFF
--- a/packages/focus-pair-reader/package.json
+++ b/packages/focus-pair-reader/package.json
@@ -25,5 +25,8 @@
 		"@types/body-scroll-lock": "^3.1.2",
 		"typescript": "^5.2.2",
 		"vite": "^5.0.8"
+	},
+	"resolutions": {
+		"rollup": "npm:@rollup/wasm-node"
 	}
 }

--- a/packages/random-pair-colors/package.json
+++ b/packages/random-pair-colors/package.json
@@ -29,5 +29,8 @@
 	"dependencies": {
 		"apca-w3": "^0.1.9",
 		"colorparsley": "^0.1.8"
+	},
+	"resolutions": {
+		"rollup": "npm:@rollup/wasm-node"
 	}
 }


### PR DESCRIPTION
[5.0.2 Cannot find module '@rollup/rollup-linux-arm64-gnu' on multi platform build · Issue #15167 · vitejs/vite](https://github.com/vitejs/vite/issues/15167)